### PR TITLE
Reverted to original quantified version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           name: Build FatJar
           command: |
             sbt assembly
-            cp target/scala-2.11/kafka-librato-monitor-assembly-*.jar /tmp/artifacts/
+            cp target/scala-2.10/kafka-librato-monitor-assembly-*.jar /tmp/artifacts/
       - store_artifacts:
           path: /tmp/artifacts
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kafka-librato-monitor
-Plugin to [kafka-offset-monitor](https://github.com/Morningstar/kafka-offset-monitor) tool reporting offset data to [Librato](https://www.librato.com/) via [dropwizard metrics](https://github.com/dropwizard/metrics) Librato [reporter](https://github.com/librato/metrics-librato)
+Plugin for [KafkaOffsetMonitor](https://github.com/quantifind/KafkaOffsetMonitor/) tool reporting offset data to [Librato](https://www.librato.com/) via [dropwizard metrics](https://github.com/dropwizard/metrics) Librato [reporter](https://github.com/librato/metrics-librato)
 
 ## Getting Started
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
@@ -26,7 +26,7 @@ Check how to run kafka-offset-monitor and modify the command by adding a plugin 
 See original kafka-offset-monitor example command modified with Librato reporter plugin usage:
 
 ```
-java -cp "kafka-offset-monitor-assembly-0.4.6-SNAPSHOT.jar:kafka-librato-monitor-assembly-0.2.0.jar" \
+java -cp "kafka-offset-monitor-assembly-0.3.0-SNAPSHOT.jar:kafka-librato-monitor-assembly-0.3.0.jar" \
      com.quantifind.kafka.offsetapp.OffsetGetterWeb \
      --kafkaBrokers broker1:9092,broker2:9092
      --zk zk-server1,zk-server2,zk-server-3 \
@@ -47,7 +47,7 @@ The pluginArgs used by kafka-librato-monitor are:
 
 ## Built With
 
-* [kafka-offset-monitor](https://github.com/Morningstar/kafka-offset-monitor)
+* [KafkaOffsetMonitor](https://github.com/quantifind/KafkaOffsetMonitor/)
 * [Dropwizard Metrics](http://metrics.dropwizard.io/) - Toolkit of ways to measure the behavior of an application
 * [metrics-librato](https://github.com/librato/metrics-librato) - Librato reporter for Dropwizard Metrics
 
@@ -64,6 +64,7 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
 
 ## Acknowledgments
-* Special thanks to authors & maintainers of [KafkaOffsetMonitor](https://github.com/quantifind/KafkaOffsetMonitor) & its [fork](https://github.com/Morningstar/kafka-offset-monitor) by Morningstar for creating this awesome tool with support for plugins.
+* Special thanks to authors & maintainers of [KafkaOffsetMonitor](https://github.com/quantifind/KafkaOffsetMonitor) for creating this awesome tool with support for plugins.
 * This project is replica of [kafka-offset-monitor-graphite](https://github.com/allegro/kafka-offset-monitor-graphite) for Librato. Thank you for providing this graphite plugin. Future work - maybe we could convert this project into generic dropwizard monitor.
 * This Readme is inspired from [Readme Template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)
+

--- a/build.sbt
+++ b/build.sbt
@@ -2,21 +2,14 @@ name := "kafka-librato-monitor"
 
 organization := "mix.kafka"
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.10.3"
 
 // Dependencies
 libraryDependencies ++= Seq(
   "com.github.ben-manes.caffeine" % "caffeine" % "1.0.0",
-  "com.quantifind" %% "kafkaoffsetmonitor" % "0.4.6-SNAPSHOT",
+  "com.quantifind" %% "kafkaoffsetmonitor" % "0.3.0-SNAPSHOT",
   "com.librato.metrics" % "metrics-librato" % "5.0.5",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-
-  // explicitly adding trasnsistive dependency to fix issue with ${packaging.type} - https://github.com/sbt/sbt/issues/3618
-  "org.reflections" % "reflections" % "0.9.11" artifacts( Artifact("reflections", "jar", "jar"))
-)
-
-dependencyOverrides ++= Seq(
-  "org.apache.kafka" %% "kafka" % "0.10.0.1"
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
 // To remove multiple exclusions

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,9 @@ scalacOptions := Seq("-deprecation",
   "-language:implicitConversions"
 )
 
+//assembly Settings
+test in assembly := {}
+
 // set Ivy logging to be at the highest level, if needed for debugging
 ivyLoggingLevel := UpdateLogging.Quiet
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0"
+version in ThisBuild := "0.3.0"


### PR DESCRIPTION
As it turns out - I was not able to make Morningstar fork of this library work with our plugin. After resolving some minor configuration issues, getting exceptions which looks like due to kafka version issues. 

So, rather spending more time trying to resolve that error - instead reverting to original version which is obviously more tested & was working in production at Mix for quite sometime now. 

Still, this lib is upgraded with CircleCI 2.0 & sbt 1.0.2 but using scala 2.10. I see an open issue in the original project so hopefully might get released soon. Also saw that original project was last updated 5 months - so might be still ok to rely on that.